### PR TITLE
Add confirmation dialog before deleting an assignment

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,7 @@ export default function Dashboard() {
   }, []);
 
   function handleDelete(id: string) {
+    if (!window.confirm("Delete this assignment? This cannot be undone.")) return;
     deleteAssignment(id);
     setAssignments((prev) => prev.filter((a) => a.id !== id));
   }


### PR DESCRIPTION
## Summary
- Adds a `window.confirm` dialog when clicking Delete on an assignment
- User must confirm before the assignment is removed
- Closes #1

## Test plan
- [ ] Click Delete on an assignment — confirm dialog should appear
- [ ] Click Cancel — assignment should not be deleted
- [ ] Click OK — assignment should be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)