### PR TITLE
Add file upload support for assignment estimation

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,24 +1,96 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { addAssignment } from "@/lib/storage";
 import DatePicker from "@/components/DatePicker";
 
+const ALLOWED_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+  "application/pdf",
+  "text/plain",
+]);
+
+const MAX_FILE_BYTES = 20 * 1024 * 1024; // 20MB
+
 export default function AddAssignment() {
   const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
+  const [fileData, setFileData] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [fileMimeType, setFileMimeType] = useState<string | null>(null);
+
+  function clearFile() {
+    setFileData(null);
+    setFileName(null);
+    setFileMimeType(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setError("");
+
+    if (!ALLOWED_TYPES.has(file.type)) {
+      setError("Unsupported file type. Please upload a PDF, image, or .txt file.");
+      e.target.value = "";
+      return;
+    }
+
+    if (file.size > MAX_FILE_BYTES) {
+      setError("File is too large (max 20MB).");
+      e.target.value = "";
+      return;
+    }
+
+    const reader = new FileReader();
+
+    if (file.type === "text/plain") {
+      reader.onload = () => {
+        const text = reader.result as string;
+        setDescription((prev) => (prev.trim() ? prev + "\n\n" + text : text));
+        clearFile();
+      };
+      reader.onerror = () => setError("Could not read file.");
+      reader.readAsText(file);
+    } else {
+      reader.onload = () => {
+        const dataUrl = reader.result as string;
+        const base64 = dataUrl.split(",")[1];
+        setFileData(base64);
+        setFileName(file.name);
+        setFileMimeType(file.type);
+      };
+      reader.onerror = () => setError("Could not read file.");
+      reader.readAsDataURL(file);
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+
+    if (!description.trim() && !fileData) {
+      setError("Please add a description or upload a file.");
+      return;
+    }
+
     if (!dueDate) {
       setError("Please select a due date.");
       return;
     }
+
     setLoading(true);
     setError("");
 
@@ -26,7 +98,7 @@ export default function AddAssignment() {
       const res = await fetch("/api/estimate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ description }),
+        body: JSON.stringify({ description, fileData, fileName, fileMimeType }),
       });
 
       if (!res.ok) throw new Error("Estimation failed");
@@ -36,7 +108,7 @@ export default function AddAssignment() {
       addAssignment({
         id: crypto.randomUUID(),
         title,
-        description,
+        description: description.trim() || fileName || "Uploaded file",
         dueDate,
         estimatedMinutes,
         reasoning,
@@ -71,13 +143,40 @@ export default function AddAssignment() {
             Assignment Description
           </label>
           <textarea
-            required
             rows={6}
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             placeholder="Paste the assignment description here..."
             className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
           />
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">
+            Upload File{" "}
+            <span className="font-normal text-zinc-500">(PDF, image, or .txt)</span>
+          </label>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".pdf,image/png,image/jpeg,image/webp,image/gif,text/plain"
+            onChange={handleFileChange}
+            className="block w-full text-sm text-zinc-600 file:mr-3 file:rounded-md file:border-0 file:bg-zinc-100 file:px-3 file:py-1.5 file:text-sm file:font-medium hover:file:bg-zinc-200 dark:text-zinc-400 dark:file:bg-zinc-800 dark:hover:file:bg-zinc-700"
+          />
+          {fileName && (
+            <div className="mt-2 flex items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400">
+              <span className="rounded-full bg-zinc-100 px-3 py-0.5 dark:bg-zinc-800">
+                {fileName}
+              </span>
+              <button
+                type="button"
+                onClick={clearFile}
+                className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200"
+                aria-label="Remove file"
+              >
+                ×
+              </button>
+            </div>
+          )}
         </div>
         <div>
           <label className="mb-1 block text-sm font-medium">Due Date</label>

--- a/src/app/api/estimate/route.ts
+++ b/src/app/api/estimate/route.ts
@@ -1,6 +1,7 @@
 import { generateText, Output } from "ai";
 import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
+import type { TextPart, ImagePart, FilePart } from "ai";
 
 const schema = z.object({
   estimatedMinutes: z
@@ -12,14 +13,42 @@ const schema = z.object({
 });
 
 export async function POST(req: Request) {
-  const { description } = await req.json();
+  const { description, fileData, fileName, fileMimeType } = await req.json();
+
+  const content: Array<TextPart | ImagePart | FilePart> = [];
+
+  if (description?.trim()) {
+    content.push({ type: "text", text: description });
+  }
+
+  if (fileData && fileMimeType) {
+    if (fileMimeType.startsWith("image/")) {
+      content.push({ type: "image", image: fileData, mediaType: fileMimeType });
+    } else if (fileMimeType === "application/pdf") {
+      content.push({
+        type: "file",
+        data: fileData,
+        mediaType: "application/pdf",
+        filename: fileName ?? undefined,
+      });
+    }
+  }
+
+  if (content.length === 0) {
+    return Response.json({ error: "No content provided" }, { status: 400 });
+  }
 
   const { output } = await generateText({
     model: anthropic("claude-sonnet-4-6"),
     output: Output.object({ schema }),
     system:
       "You are a study time estimator for college students. Given an assignment description, estimate how many minutes it will take an average college student to complete. Be realistic — students tend to underestimate. Return your estimate and a brief reasoning.",
-    prompt: description,
+    messages: [{ role: "user", content }],
+    providerOptions: {
+      anthropic: fileMimeType === "application/pdf"
+        ? { anthropicBeta: ["pdfs-2024-09-25"] }
+        : {},
+    },
   });
 
   return Response.json(output);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">
+      <body className="min-h-full flex flex-col" suppressHydrationWarning>
         <Nav />
         <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-8">
           {children}


### PR DESCRIPTION
## Summary

- Adds a file input to the add assignment form accepting PDFs, images (PNG/JPG/WebP/GIF), and `.txt` files
- Files are base64-encoded in the browser and sent to `/api/estimate`; Claude reads them natively via multimodal message content — no new parsing libraries needed
- `.txt` files are read as text and dropped into the description textarea rather than sent as a file attachment
- Uploaded filename is used as the stored description fallback when no text is provided
- Fixes hydration warning caused by browser extensions injecting attributes into `<body>`

## Test plan

- [ ] Paste text only → estimate works as before
- [ ] Upload a PNG/JPG screenshot → Claude estimates from image content
- [ ] Upload a PDF → Claude estimates from PDF content
- [ ] Upload a `.txt` file → content populates the textarea, estimates normally
- [ ] Upload file + add extra text → both reach Claude
- [ ] Upload unsupported type (e.g. `.docx`) → shows "Unsupported file type" error
- [ ] Submit with no text and no file → shows validation error
- [ ] Check browser console — hydration warning should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)