### PR TITLE
Replace drag grid with typed time blocks for weekly availability

### DIFF
--- a/src/app/api/parse-schedule/route.ts
+++ b/src/app/api/parse-schedule/route.ts
@@ -1,0 +1,59 @@
+import { generateText, Output } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { z } from "zod";
+
+const schema = z.object({
+  blocks: z.array(
+    z.object({
+      day: z.enum([
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+      ]),
+      start: z.string().describe("24h HH:MM format, e.g. 09:00"),
+      end: z.string().describe("24h HH:MM format, e.g. 11:30"),
+    })
+  ),
+});
+
+export async function POST(req: Request) {
+  const { fileData, fileMimeType } = await req.json();
+
+  if (!fileData || !fileMimeType) {
+    return Response.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  const { output } = await generateText({
+    model: anthropic("claude-sonnet-4-6"),
+    output: Output.object({ schema }),
+    system: `You are reading a weekly calendar screenshot.
+Identify all busy blocks (classes, appointments, commitments) shown on the calendar.
+Then return the FREE windows between those busy blocks for each day of the week, within typical study hours (7am–11pm).
+Only return windows of at least 30 minutes.
+If a day has no events, return the full 7am–11pm window for that day.
+Use 24-hour HH:MM format for times (e.g. 09:00, 13:30, 23:00).
+Use lowercase full day names (monday, tuesday, etc.).`,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Here is my weekly calendar. Please extract my free study windows.",
+          },
+          {
+            type: "image",
+            image: fileData,
+            mediaType: fileMimeType as "image/png" | "image/jpeg" | "image/webp" | "image/gif",
+          },
+        ],
+      },
+    ],
+  });
+
+  return Response.json(output);
+}

--- a/src/app/availability/page.tsx
+++ b/src/app/availability/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { AvailabilityGrid } from "@/lib/types";
+import { useEffect, useRef, useState } from "react";
+import type { Availability, AvailabilityBlock, Day } from "@/lib/types";
 import { getAvailability, saveAvailability } from "@/lib/storage";
 
-const DAYS = [
+const DAYS: Day[] = [
   "monday",
   "tuesday",
   "wednesday",
@@ -13,101 +13,221 @@ const DAYS = [
   "saturday",
   "sunday",
 ];
-const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-const HOURS = Array.from({ length: 16 }, (_, i) => i + 7); // 7am-10pm
 
-function formatHour(h: number) {
-  if (h === 0 || h === 12) return `12${h === 0 ? "am" : "pm"}`;
-  return h < 12 ? `${h}am` : `${h - 12}pm`;
+const DAY_LABELS: Record<Day, string> = {
+  monday: "Monday",
+  tuesday: "Tuesday",
+  wednesday: "Wednesday",
+  thursday: "Thursday",
+  friday: "Friday",
+  saturday: "Saturday",
+  sunday: "Sunday",
+};
+
+function formatTime(t: string): string {
+  const [h, m] = t.split(":").map(Number);
+  const suffix = h < 12 ? "am" : "pm";
+  const hour = h % 12 === 0 ? 12 : h % 12;
+  return `${hour}:${m.toString().padStart(2, "0")}${suffix}`;
 }
 
+function toMinutes(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+const emptyPerDay = () =>
+  Object.fromEntries(DAYS.map((d) => [d, ""])) as Record<Day, string>;
+
 export default function Availability() {
-  const [grid, setGrid] = useState<AvailabilityGrid>({});
-  const [isDragging, setIsDragging] = useState(false);
-  const [dragValue, setDragValue] = useState(false);
+  const [blocks, setBlocks] = useState<Availability>([]);
+  const [newStart, setNewStart] = useState<Record<Day, string>>(emptyPerDay());
+  const [newEnd, setNewEnd] = useState<Record<Day, string>>(emptyPerDay());
+  const [addErrors, setAddErrors] = useState<Record<Day, string>>(emptyPerDay());
+  const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    setGrid(getAvailability());
+    setBlocks(getAvailability());
   }, []);
 
-  function handleMouseDown(key: string) {
-    setIsDragging(true);
-    const newValue = !grid[key];
-    setDragValue(newValue);
-    setGrid((prev) => {
-      const next = { ...prev, [key]: newValue };
-      saveAvailability(next);
-      return next;
+  function addBlock(day: Day) {
+    const start = newStart[day];
+    const end = newEnd[day];
+
+    if (!start || !end) {
+      setAddErrors((prev) => ({ ...prev, [day]: "Enter both start and end times." }));
+      return;
+    }
+    if (toMinutes(start) >= toMinutes(end)) {
+      setAddErrors((prev) => ({ ...prev, [day]: "End time must be after start time." }));
+      return;
+    }
+    if (toMinutes(end) - toMinutes(start) < 30) {
+      setAddErrors((prev) => ({ ...prev, [day]: "Block must be at least 30 minutes." }));
+      return;
+    }
+
+    const newBlock: AvailabilityBlock = {
+      id: crypto.randomUUID(),
+      day,
+      start,
+      end,
+    };
+    const updated = [...blocks, newBlock].sort((a, b) => {
+      if (a.day !== b.day) return DAYS.indexOf(a.day) - DAYS.indexOf(b.day);
+      return toMinutes(a.start) - toMinutes(b.start);
     });
+
+    setBlocks(updated);
+    saveAvailability(updated);
+    setNewStart((prev) => ({ ...prev, [day]: "" }));
+    setNewEnd((prev) => ({ ...prev, [day]: "" }));
+    setAddErrors((prev) => ({ ...prev, [day]: "" }));
   }
 
-  function handleMouseEnter(key: string) {
-    if (!isDragging) return;
-    setGrid((prev) => {
-      const next = { ...prev, [key]: dragValue };
-      saveAvailability(next);
-      return next;
-    });
+  function deleteBlock(id: string) {
+    const updated = blocks.filter((b) => b.id !== id);
+    setBlocks(updated);
+    saveAvailability(updated);
   }
 
-  function handleMouseUp() {
-    setIsDragging(false);
+  async function handleImport(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setImporting(true);
+    setImportError("");
+
+    const reader = new FileReader();
+    reader.onload = async () => {
+      try {
+        const base64 = (reader.result as string).split(",")[1];
+        const res = await fetch("/api/parse-schedule", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ fileData: base64, fileMimeType: file.type }),
+        });
+        if (!res.ok) throw new Error();
+        const { blocks: imported } = await res.json();
+        const withIds: Availability = (
+          imported as Omit<AvailabilityBlock, "id">[]
+        ).map((b) => ({ ...b, id: crypto.randomUUID() }));
+        const merged = [...blocks, ...withIds].sort((a, b) => {
+          if (a.day !== b.day) return DAYS.indexOf(a.day) - DAYS.indexOf(b.day);
+          return toMinutes(a.start) - toMinutes(b.start);
+        });
+        setBlocks(merged);
+        saveAvailability(merged);
+      } catch {
+        setImportError("Could not parse schedule. Please try again.");
+      } finally {
+        setImporting(false);
+        if (fileInputRef.current) fileInputRef.current.value = "";
+      }
+    };
+    reader.onerror = () => {
+      setImportError("Could not read file.");
+      setImporting(false);
+    };
+    reader.readAsDataURL(file);
   }
 
   return (
-    <div>
-      <h1 className="mb-2 text-2xl font-bold">Weekly Availability</h1>
-      <p className="mb-6 text-sm text-zinc-500">
-        Click or drag to mark when you&apos;re free to study.
-      </p>
-      <div
-        className="select-none overflow-x-auto"
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseUp}
-      >
-        <div
-          className="grid gap-px"
-          style={{
-            gridTemplateColumns: "60px repeat(7, 1fr)",
-          }}
-        >
-          {/* Header */}
-          <div />
-          {DAY_LABELS.map((d) => (
-            <div
-              key={d}
-              className="py-2 text-center text-xs font-semibold text-zinc-500"
-            >
-              {d}
-            </div>
-          ))}
-          {/* Grid */}
-          {HOURS.map((h) => (
-            <>
-              <div
-                key={`label-${h}`}
-                className="flex items-center justify-end pr-2 text-xs text-zinc-400"
-              >
-                {formatHour(h)}
-              </div>
-              {DAYS.map((day) => {
-                const key = `${day}-${h}`;
-                return (
-                  <div
-                    key={key}
-                    onMouseDown={() => handleMouseDown(key)}
-                    onMouseEnter={() => handleMouseEnter(key)}
-                    className={`h-8 cursor-pointer rounded-sm border transition-colors ${
-                      grid[key]
-                        ? "border-blue-400 bg-blue-500"
-                        : "border-zinc-200 bg-zinc-50 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
-                    }`}
-                  />
-                );
-              })}
-            </>
-          ))}
+    <div className="mx-auto max-w-2xl">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Weekly Availability</h1>
+          <p className="mt-1 text-sm text-zinc-500">
+            Add the time windows when you&apos;re free to study each week.
+          </p>
         </div>
+        <div className="flex flex-col items-end gap-1">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={handleImport}
+            className="hidden"
+            id="schedule-import"
+          />
+          <label
+            htmlFor="schedule-import"
+            className={`cursor-pointer whitespace-nowrap rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800 ${
+              importing ? "pointer-events-none opacity-50" : ""
+            }`}
+          >
+            {importing ? "Importing…" : "Import from Google Calendar"}
+          </label>
+          {importError && (
+            <p className="text-xs text-red-500">{importError}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        {DAYS.map((day) => {
+          const dayBlocks = blocks.filter((b) => b.day === day);
+          return (
+            <div key={day}>
+              <h2 className="mb-2 text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+                {DAY_LABELS[day]}
+              </h2>
+
+              {dayBlocks.length > 0 && (
+                <ul className="mb-2 space-y-1">
+                  {dayBlocks.map((b) => (
+                    <li
+                      key={b.id}
+                      className="flex items-center justify-between rounded-md bg-blue-50 px-3 py-1.5 text-sm dark:bg-blue-950"
+                    >
+                      <span className="text-blue-800 dark:text-blue-200">
+                        {formatTime(b.start)} – {formatTime(b.end)}
+                      </span>
+                      <button
+                        onClick={() => deleteBlock(b.id)}
+                        className="ml-4 text-blue-400 hover:text-blue-600 dark:hover:text-blue-200"
+                        aria-label="Remove block"
+                      >
+                        ×
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              <div className="flex items-center gap-2">
+                <input
+                  type="time"
+                  value={newStart[day]}
+                  onChange={(e) =>
+                    setNewStart((prev) => ({ ...prev, [day]: e.target.value }))
+                  }
+                  className="rounded-md border border-zinc-300 px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+                />
+                <span className="text-zinc-400">–</span>
+                <input
+                  type="time"
+                  value={newEnd[day]}
+                  onChange={(e) =>
+                    setNewEnd((prev) => ({ ...prev, [day]: e.target.value }))
+                  }
+                  className="rounded-md border border-zinc-300 px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+                />
+                <button
+                  onClick={() => addBlock(day)}
+                  className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
+                >
+                  Add
+                </button>
+              </div>
+              {addErrors[day] && (
+                <p className="mt-1 text-xs text-red-500">{addErrors[day]}</p>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/lib/scheduler.test.ts
+++ b/src/lib/scheduler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { generateSchedule } from "./scheduler";
-import { Assignment, AvailabilityGrid } from "./types";
+import { Assignment, Availability } from "./types";
 
 function makeAssignment(
   overrides: Partial<Assignment> & { id: string; title: string }
@@ -18,16 +18,25 @@ function makeAssignment(
 // Monday April 6, 2026
 const WEEK_START = new Date(2026, 3, 6);
 
+// Helper: create a single availability block with a throwaway id
+function block(
+  day: Availability[number]["day"],
+  start: string,
+  end: string
+): Availability[number] {
+  return { id: `${day}-${start}`, day, start, end };
+}
+
 describe("generateSchedule", () => {
   it("returns empty blocks when no assignments", () => {
-    const result = generateSchedule([], {}, WEEK_START);
+    const result = generateSchedule([], [], WEEK_START);
     expect(result.blocks).toEqual([]);
     expect(result.atRisk).toEqual([]);
   });
 
   it("returns empty blocks when no availability", () => {
     const assignments = [makeAssignment({ id: "1", title: "Ochem" })];
-    const result = generateSchedule(assignments, {}, WEEK_START);
+    const result = generateSchedule(assignments, [], WEEK_START);
     expect(result.blocks).toEqual([]);
     expect(result.atRisk).toEqual(["1"]);
   });
@@ -36,13 +45,10 @@ describe("generateSchedule", () => {
     const assignments = [
       makeAssignment({ id: "1", title: "Ochem", estimatedMinutes: 120 }),
     ];
-    const availability: AvailabilityGrid = {
-      "monday-9": true,
-      "monday-10": true,
-      "monday-11": true,
-    };
+    // 9:00–11:00 = 4 × 30-min slots = 120 min
+    const availability: Availability = [block("monday", "09:00", "11:00")];
     const result = generateSchedule(assignments, availability, WEEK_START);
-    expect(result.blocks).toHaveLength(2);
+    expect(result.blocks).toHaveLength(4);
     expect(result.atRisk).toEqual([]);
     expect(result.blocks[0].title).toBe("Ochem");
   });
@@ -51,12 +57,10 @@ describe("generateSchedule", () => {
     const assignments = [
       makeAssignment({ id: "1", title: "Ochem", estimatedMinutes: 180 }),
     ];
-    const availability: AvailabilityGrid = {
-      "monday-9": true,
-      "monday-10": true,
-    };
+    // 9:00–11:00 = 120 min, not enough for 180
+    const availability: Availability = [block("monday", "09:00", "11:00")];
     const result = generateSchedule(assignments, availability, WEEK_START);
-    expect(result.blocks).toHaveLength(2);
+    expect(result.blocks).toHaveLength(4);
     expect(result.atRisk).toEqual(["1"]);
   });
 
@@ -75,13 +79,11 @@ describe("generateSchedule", () => {
         estimatedMinutes: 60,
       }),
     ];
-    const availability: AvailabilityGrid = {
-      "monday-9": true,
-      "monday-10": true,
-    };
+    // 9:00–11:00 = 4 × 30 min = 120 min (enough for both)
+    const availability: Availability = [block("monday", "09:00", "11:00")];
     const result = generateSchedule(assignments, availability, WEEK_START);
     expect(result.blocks[0].title).toBe("Ochem");
-    expect(result.blocks[1].title).toBe("Bio");
+    expect(result.blocks[2].title).toBe("Bio");
   });
 
   it("does not schedule past the due date", () => {
@@ -93,37 +95,26 @@ describe("generateSchedule", () => {
         estimatedMinutes: 180,
       }),
     ];
-    const availability: AvailabilityGrid = {
-      "monday-9": true,
-      "monday-10": true,
-      "tuesday-9": true, // past due date
-    };
+    // Monday 9:00–11:00 = 4 slots (120 min), Tuesday (past due) ignored
+    const availability: Availability = [
+      block("monday", "09:00", "11:00"),
+      block("tuesday", "09:00", "10:00"),
+    ];
     const result = generateSchedule(assignments, availability, WEEK_START);
-    expect(result.blocks).toHaveLength(2);
+    expect(result.blocks).toHaveLength(4);
     expect(result.atRisk).toEqual(["1"]);
   });
 
   it("does not double-book slots across assignments", () => {
     const assignments = [
-      makeAssignment({
-        id: "1",
-        title: "Ochem",
-        estimatedMinutes: 60,
-      }),
-      makeAssignment({
-        id: "2",
-        title: "Bio",
-        estimatedMinutes: 60,
-      }),
+      makeAssignment({ id: "1", title: "Ochem", estimatedMinutes: 60 }),
+      makeAssignment({ id: "2", title: "Bio", estimatedMinutes: 60 }),
     ];
-    const availability: AvailabilityGrid = {
-      "monday-9": true,
-      "monday-10": true,
-    };
+    // 9:00–11:00 = 4 × 30-min slots, enough for both 60-min assignments
+    const availability: Availability = [block("monday", "09:00", "11:00")];
     const result = generateSchedule(assignments, availability, WEEK_START);
-    expect(result.blocks).toHaveLength(2);
-    // Each assignment gets a different slot
+    expect(result.blocks).toHaveLength(4);
     const starts = result.blocks.map((b) => b.start.getTime());
-    expect(new Set(starts).size).toBe(2);
+    expect(new Set(starts).size).toBe(4);
   });
 });

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs";
-import { Assignment, AvailabilityGrid, ScheduleBlock } from "./types";
+import { Assignment, Availability, Day, ScheduleBlock } from "./types";
 
-const DAYS = [
+const DAYS: Day[] = [
   "sunday",
   "monday",
   "tuesday",
@@ -13,12 +13,12 @@ const DAYS = [
 
 /**
  * Greedy scheduler: sorts assignments by due date, fills earliest available
- * slots until estimated time is covered. Won't schedule past due date.
+ * 30-minute slots until estimated time is covered. Won't schedule past due date.
  * Returns schedule blocks + list of at-risk assignment IDs.
  */
 export function generateSchedule(
   assignments: Assignment[],
-  availability: AvailabilityGrid,
+  availability: Availability,
   weekStart: Date
 ): { blocks: ScheduleBlock[]; atRisk: string[] } {
   const sorted = [...assignments].sort(
@@ -28,21 +28,33 @@ export function generateSchedule(
   const blocks: ScheduleBlock[] = [];
   const atRisk: string[] = [];
 
-  // Build list of available 1-hour slots for the week, sorted chronologically
+  // Build list of available 30-minute slots for the week, sorted chronologically
   const slots: { start: dayjs.Dayjs; end: dayjs.Dayjs }[] = [];
+
   for (let d = 0; d < 7; d++) {
     const day = dayjs(weekStart).add(d, "day");
     const dayName = DAYS[day.day()];
-    for (let h = 7; h < 23; h++) {
-      const key = `${dayName}-${h}`;
-      if (availability[key]) {
-        slots.push({
-          start: day.hour(h).minute(0).second(0),
-          end: day.hour(h + 1).minute(0).second(0),
-        });
+    const dayBlocks = availability.filter((b) => b.day === dayName);
+
+    for (const block of dayBlocks) {
+      const [startH, startM] = block.start.split(":").map(Number);
+      const [endH, endM] = block.end.split(":").map(Number);
+      let cursor = day.hour(startH).minute(startM).second(0);
+      const blockEnd = day.hour(endH).minute(endM).second(0);
+
+      while (
+        cursor.add(30, "minute").isBefore(blockEnd) ||
+        cursor.add(30, "minute").isSame(blockEnd)
+      ) {
+        slots.push({ start: cursor, end: cursor.add(30, "minute") });
+        cursor = cursor.add(30, "minute");
       }
     }
   }
+
+  // Sort slots chronologically (blocks within a day are already ordered,
+  // but multiple days need merging in order)
+  slots.sort((a, b) => a.start.valueOf() - b.start.valueOf());
 
   const usedSlots = new Set<number>();
 
@@ -55,7 +67,7 @@ export function generateSchedule(
       if (slots[i].start.isAfter(dueDate)) break;
 
       usedSlots.add(i);
-      remainingMinutes -= 60;
+      remainingMinutes -= 30;
 
       blocks.push({
         id: `${assignment.id}-${i}`,

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,4 +1,4 @@
-import { Assignment, AvailabilityGrid } from "./types";
+import { Assignment, Availability } from "./types";
 
 const ASSIGNMENTS_KEY = "study-scheduler-assignments";
 const AVAILABILITY_KEY = "study-scheduler-availability";
@@ -24,12 +24,21 @@ export function deleteAssignment(id: string) {
   saveAssignments(assignments);
 }
 
-export function getAvailability(): AvailabilityGrid {
-  if (typeof window === "undefined") return {};
-  const raw = localStorage.getItem(AVAILABILITY_KEY);
-  return raw ? JSON.parse(raw) : {};
+export function getAvailability(): Availability {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(AVAILABILITY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    // Guard against old grid format (object, not array)
+    if (!Array.isArray(parsed)) return [];
+    return parsed as Availability;
+  } catch {
+    return [];
+  }
 }
 
-export function saveAvailability(grid: AvailabilityGrid) {
-  localStorage.setItem(AVAILABILITY_KEY, JSON.stringify(grid));
+export function saveAvailability(blocks: Availability): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(AVAILABILITY_KEY, JSON.stringify(blocks));
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,4 +17,20 @@ export interface ScheduleBlock {
   type: "study" | "busy";
 }
 
-export type AvailabilityGrid = Record<string, boolean>; // "day-hour" -> available
+export type Day =
+  | "sunday"
+  | "monday"
+  | "tuesday"
+  | "wednesday"
+  | "thursday"
+  | "friday"
+  | "saturday";
+
+export interface AvailabilityBlock {
+  id: string;
+  day: Day;
+  start: string; // "09:00" — 24h HH:MM
+  end: string;   // "11:30" — 24h HH:MM
+}
+
+export type Availability = AvailabilityBlock[];


### PR DESCRIPTION
## Summary

- Replaces the hourly drag-to-select grid with a day-by-day list of explicit free windows (start/end time inputs)
- `<input type="time">` fields let you type any time directly or use the browser picker — covers 12:30–1:30 and any other sub-hour range
- Availability stored as `AvailabilityBlock[]` (`{ id, day, start, end }`) instead of the old `Record<"day-hour", boolean>` — old data silently cleared on first load
- Scheduler now emits 30-minute slots within each free block instead of fixed 1-hour chunks
- Adds **Import from Google Calendar** button: upload a screenshot, Claude extracts busy blocks and returns free study windows, pre-populated into the list
- All 7 scheduler tests updated and passing

## Test plan

- [ ] Add a block: Monday 9:00–11:30 → appears, persists on reload
- [ ] Add a block with end before start → inline error shown
- [ ] Add a block under 30 min → inline error shown
- [ ] Delete a block → removed immediately
- [ ] Load `/schedule` → study blocks appear at correct sub-hour times
- [ ] Upload a Google Calendar screenshot → free windows pre-populated
- [ ] `npm test` → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)