### PR TITLE
Add time-of-day study preference setting

### DIFF
--- a/src/app/availability/page.tsx
+++ b/src/app/availability/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Availability, AvailabilityBlock, Day } from "@/lib/types";
-import { DAYS_FROM_MONDAY, DAY_LABELS } from "@/lib/types";
-import { getAvailability, saveAvailability } from "@/lib/storage";
+import type { Availability, AvailabilityBlock, Day, StudyTimePreference } from "@/lib/types";
+import { DAYS_FROM_MONDAY, DAY_LABELS, STUDY_TIME_RANGES } from "@/lib/types";
+import { getAvailability, saveAvailability, getStudyTimePreference, saveStudyTimePreference } from "@/lib/storage";
 import { useAuth } from "@/lib/auth";
 import { formatTime, toMinutes, sortAvailabilityBlocks } from "@/lib/time";
 
@@ -13,6 +13,7 @@ const emptyPerDay = () =>
 export default function AvailabilityPage() {
   const { user } = useAuth();
   const [blocks, setBlocks] = useState<Availability>([]);
+  const [preference, setPreference] = useState<StudyTimePreference>("none");
   const [newStart, setNewStart] = useState<Record<Day, string>>(emptyPerDay());
   const [newEnd, setNewEnd] = useState<Record<Day, string>>(emptyPerDay());
   const [addErrors, setAddErrors] = useState<Record<Day, string>>(emptyPerDay());
@@ -24,7 +25,12 @@ export default function AvailabilityPage() {
   const load = useCallback(async () => {
     if (!user) return;
     try {
-      setBlocks(await getAvailability(user.uid));
+      const [avail, pref] = await Promise.all([
+        getAvailability(user.uid),
+        getStudyTimePreference(user.uid),
+      ]);
+      setBlocks(avail);
+      setPreference(pref);
     } catch {
       setLoadError("Could not load availability. Please try refreshing.");
     }
@@ -78,6 +84,16 @@ export default function AvailabilityPage() {
   function deleteBlock(id: string) {
     const updated = blocks.filter((b) => b.id !== id);
     persistBlocks(updated);
+  }
+
+  async function handlePreferenceChange(pref: StudyTimePreference) {
+    if (!user) return;
+    setPreference(pref);
+    try {
+      await saveStudyTimePreference(user.uid, pref);
+    } catch {
+      setLoadError("Could not save preference. Please try again.");
+    }
   }
 
   async function handleImport(e: React.ChangeEvent<HTMLInputElement>) {
@@ -152,6 +168,39 @@ export default function AvailabilityPage() {
       {loadError && (
         <p className="mb-4 text-sm text-red-500">{loadError}</p>
       )}
+
+      <div className="mb-6 rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
+        <label className="mb-2 block text-sm font-medium">
+          Preferred study time
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {(
+            [
+              { value: "none" as const, label: "No preference" },
+              ...Object.entries(STUDY_TIME_RANGES).map(([value, { label }]) => ({
+                value: value as StudyTimePreference,
+                label,
+              })),
+            ] as { value: StudyTimePreference; label: string }[]
+          ).map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => handlePreferenceChange(opt.value)}
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                preference === opt.value
+                  ? "bg-blue-500 text-white"
+                  : "border border-zinc-300 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <p className="mt-2 text-xs text-zinc-500">
+          The scheduler will prioritize placing study blocks during your preferred hours.
+        </p>
+      </div>
 
       <div className="space-y-6">
         {DAYS_FROM_MONDAY.map((day) => {

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Calendar, dayjsLocalizer } from "react-big-calendar";
 import dayjs from "dayjs";
-import { getAssignments, getAvailability } from "@/lib/storage";
+import { getAssignments, getAvailability, getStudyTimePreference } from "@/lib/storage";
 import { generateSchedule } from "@/lib/scheduler";
 import { useAuth } from "@/lib/auth";
 import { Assignment, ScheduleBlock } from "@/lib/types";
@@ -20,12 +20,15 @@ export default function SchedulePage() {
   const load = useCallback(async () => {
     if (!user) return;
     try {
-      const a = await getAssignments(user.uid);
+      const [a, availability, preference] = await Promise.all([
+        getAssignments(user.uid),
+        getAvailability(user.uid),
+        getStudyTimePreference(user.uid),
+      ]);
       setAssignments(a);
 
-      const availability = await getAvailability(user.uid);
       const now = dayjs().startOf("week");
-      const result = generateSchedule(a, availability, now.toDate());
+      const result = generateSchedule(a, availability, now.toDate(), new Date(), preference);
       setBlocks(result.blocks);
       setAtRisk(result.atRisk);
     } catch {

--- a/src/lib/scheduler.test.ts
+++ b/src/lib/scheduler.test.ts
@@ -267,4 +267,85 @@ describe("generateSchedule", () => {
     expect(result.blocks[2].start.getMinutes()).toBe(0);
     expect(result.blocks[2].end.getMinutes()).toBe(30);
   });
+
+  it("prioritizes morning slots when preference is morning", () => {
+    const assignments = [
+      makeAssignment({ id: "1", title: "Ochem", estimatedMinutes: 60 }),
+    ];
+    // Morning 9–10 and evening 18–19 both available
+    const availability: Availability = [
+      block("monday", "18:00", "19:00"),
+      block("monday", "09:00", "10:00"),
+    ];
+    const result = generateSchedule(assignments, availability, WEEK_START, new Date(0), "morning");
+    expect(result.blocks).toHaveLength(2);
+    // Should pick morning slots first
+    expect(result.blocks[0].start.getHours()).toBe(9);
+    expect(result.blocks[1].start.getHours()).toBe(9);
+  });
+
+  it("prioritizes evening slots when preference is evening", () => {
+    const assignments = [
+      makeAssignment({ id: "1", title: "Ochem", estimatedMinutes: 60 }),
+    ];
+    // Morning 9–10 and evening 18–19 both available
+    const availability: Availability = [
+      block("monday", "09:00", "10:00"),
+      block("monday", "18:00", "19:00"),
+    ];
+    const result = generateSchedule(assignments, availability, WEEK_START, new Date(0), "evening");
+    expect(result.blocks).toHaveLength(2);
+    // Should pick evening slots first
+    expect(result.blocks[0].start.getHours()).toBe(18);
+    expect(result.blocks[1].start.getHours()).toBe(18);
+  });
+
+  it("falls back to non-preferred slots when preferred are full", () => {
+    const assignments = [
+      makeAssignment({ id: "1", title: "Ochem", estimatedMinutes: 120 }),
+    ];
+    // Only 1 hour in afternoon, 1 hour in morning
+    const availability: Availability = [
+      block("monday", "09:00", "10:00"),
+      block("monday", "14:00", "15:00"),
+    ];
+    const result = generateSchedule(assignments, availability, WEEK_START, new Date(0), "afternoon");
+    expect(result.blocks).toHaveLength(4);
+    expect(result.atRisk).toEqual([]);
+    // Afternoon slots first, then morning
+    expect(result.blocks[0].start.getHours()).toBe(14);
+    expect(result.blocks[1].start.getHours()).toBe(14);
+    expect(result.blocks[2].start.getHours()).toBe(9);
+    expect(result.blocks[3].start.getHours()).toBe(9);
+  });
+
+  it("preserves day order with preference (does not pull later days forward)", () => {
+    const assignments = [
+      makeAssignment({ id: "1", title: "Ochem", estimatedMinutes: 60 }),
+    ];
+    // Tuesday evening and Monday morning
+    const availability: Availability = [
+      block("monday", "09:00", "10:00"),
+      block("tuesday", "18:00", "19:00"),
+    ];
+    const result = generateSchedule(assignments, availability, WEEK_START, new Date(0), "evening");
+    expect(result.blocks).toHaveLength(2);
+    // Should still use Monday first (day order preserved), even though preference is evening
+    expect(result.blocks[0].start.getDay()).toBe(1); // Monday
+  });
+
+  it("preference none behaves like no preference", () => {
+    const assignments = [
+      makeAssignment({ id: "1", title: "Ochem", estimatedMinutes: 60 }),
+    ];
+    const availability: Availability = [
+      block("monday", "09:00", "10:00"),
+      block("monday", "18:00", "19:00"),
+    ];
+    const withNone = generateSchedule(assignments, availability, WEEK_START, new Date(0), "none");
+    const withoutPref = generateSchedule(assignments, availability, WEEK_START, new Date(0));
+    expect(withNone.blocks.map((b) => b.start.getTime())).toEqual(
+      withoutPref.blocks.map((b) => b.start.getTime())
+    );
+  });
 });

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -1,5 +1,12 @@
 import dayjs from "dayjs";
-import { Assignment, Availability, DAYS_FROM_SUNDAY, ScheduleBlock } from "./types";
+import {
+  Assignment,
+  Availability,
+  DAYS_FROM_SUNDAY,
+  ScheduleBlock,
+  StudyTimePreference,
+  STUDY_TIME_RANGES,
+} from "./types";
 import { parseTime } from "./time";
 
 /**
@@ -11,7 +18,8 @@ export function generateSchedule(
   assignments: Assignment[],
   availability: Availability,
   weekStart: Date,
-  now: Date = new Date()
+  now: Date = new Date(),
+  preference: StudyTimePreference = "none"
 ): { blocks: ScheduleBlock[]; atRisk: string[] } {
   const sorted = [...assignments].sort(
     (a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime()
@@ -51,6 +59,24 @@ export function generateSchedule(
   // Sort slots chronologically (blocks within a day are already ordered,
   // but multiple days need merging in order)
   slots.sort((a, b) => a.start.valueOf() - b.start.valueOf());
+
+  // If user has a time-of-day preference, sort preferred-hour slots first
+  // within each day while preserving day order
+  if (preference !== "none") {
+    const range = STUDY_TIME_RANGES[preference];
+    slots.sort((a, b) => {
+      // Keep day order stable
+      const dayDiff = a.start.startOf("day").valueOf() - b.start.startOf("day").valueOf();
+      if (dayDiff !== 0) return dayDiff;
+      // Within same day, preferred hours come first
+      const aInRange = a.start.hour() >= range.startHour && a.start.hour() < range.endHour;
+      const bInRange = b.start.hour() >= range.startHour && b.start.hour() < range.endHour;
+      if (aInRange && !bInRange) return -1;
+      if (!aInRange && bInRange) return 1;
+      // Both in or both out — keep chronological
+      return a.start.valueOf() - b.start.valueOf();
+    });
+  }
 
   const usedSlots = new Set<number>();
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -8,7 +8,8 @@ import {
   orderBy,
 } from "firebase/firestore";
 import { db } from "./firebase";
-import { Assignment, Availability, AvailabilityBlock } from "./types";
+import { getDoc } from "firebase/firestore";
+import { Assignment, Availability, AvailabilityBlock, StudyTimePreference } from "./types";
 
 function getDb() {
   if (!db) throw new Error("Firestore not initialized");
@@ -33,6 +34,18 @@ export async function addAssignment(uid: string, assignment: Assignment) {
 
 export async function deleteAssignment(uid: string, id: string) {
   await deleteDoc(doc(getDb(), "users", uid, "assignments", id));
+}
+
+// --- Preferences ---
+
+export async function getStudyTimePreference(uid: string): Promise<StudyTimePreference> {
+  const snap = await getDoc(doc(getDb(), "users", uid, "preferences", "studyTime"));
+  if (!snap.exists()) return "none";
+  return (snap.data().value as StudyTimePreference) ?? "none";
+}
+
+export async function saveStudyTimePreference(uid: string, pref: StudyTimePreference) {
+  await setDoc(doc(getDb(), "users", uid, "preferences", "studyTime"), { value: pref });
 }
 
 // --- Availability ---

--- a/src/lib/time.test.ts
+++ b/src/lib/time.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { parseTime, formatTime, toMinutes, sortAvailabilityBlocks } from "./time";
+import type { AvailabilityBlock, Day } from "./types";
+import { DAYS_FROM_MONDAY } from "./types";
+
+describe("parseTime", () => {
+  it("parses HH:MM into [hours, minutes]", () => {
+    expect(parseTime("09:30")).toEqual([9, 30]);
+    expect(parseTime("14:00")).toEqual([14, 0]);
+    expect(parseTime("00:00")).toEqual([0, 0]);
+    expect(parseTime("23:59")).toEqual([23, 59]);
+  });
+});
+
+describe("formatTime", () => {
+  it("formats 24h time to 12h with suffix", () => {
+    expect(formatTime("09:00")).toBe("9:00am");
+    expect(formatTime("09:30")).toBe("9:30am");
+    expect(formatTime("12:00")).toBe("12:00pm");
+    expect(formatTime("13:00")).toBe("1:00pm");
+    expect(formatTime("00:00")).toBe("12:00am");
+    expect(formatTime("23:45")).toBe("11:45pm");
+  });
+});
+
+describe("toMinutes", () => {
+  it("converts HH:MM to total minutes since midnight", () => {
+    expect(toMinutes("00:00")).toBe(0);
+    expect(toMinutes("01:30")).toBe(90);
+    expect(toMinutes("09:00")).toBe(540);
+    expect(toMinutes("14:15")).toBe(855);
+    expect(toMinutes("23:59")).toBe(1439);
+  });
+});
+
+describe("sortAvailabilityBlocks", () => {
+  function block(day: Day, start: string, end: string): AvailabilityBlock {
+    return { id: `${day}-${start}`, day, start, end };
+  }
+
+  it("sorts by day order then by start time", () => {
+    const blocks = [
+      block("wednesday", "09:00", "10:00"),
+      block("monday", "14:00", "15:00"),
+      block("monday", "09:00", "10:00"),
+    ];
+    const sorted = sortAvailabilityBlocks(blocks, DAYS_FROM_MONDAY);
+    expect(sorted.map((b) => `${b.day}-${b.start}`)).toEqual([
+      "monday-09:00",
+      "monday-14:00",
+      "wednesday-09:00",
+    ]);
+  });
+
+  it("does not mutate the original array", () => {
+    const blocks = [
+      block("tuesday", "09:00", "10:00"),
+      block("monday", "09:00", "10:00"),
+    ];
+    const original = [...blocks];
+    sortAvailabilityBlocks(blocks, DAYS_FROM_MONDAY);
+    expect(blocks).toEqual(original);
+  });
+
+  it("handles empty array", () => {
+    expect(sortAvailabilityBlocks([], DAYS_FROM_MONDAY)).toEqual([]);
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,6 +35,17 @@ export interface AvailabilityBlock {
 
 export type Availability = AvailabilityBlock[];
 
+export type StudyTimePreference = "morning" | "afternoon" | "evening" | "none";
+
+export const STUDY_TIME_RANGES: Record<
+  Exclude<StudyTimePreference, "none">,
+  { startHour: number; endHour: number; label: string }
+> = {
+  morning: { startHour: 6, endHour: 12, label: "Morning (6am\u201312pm)" },
+  afternoon: { startHour: 12, endHour: 18, label: "Afternoon (12pm\u20136pm)" },
+  evening: { startHour: 18, endHour: 24, label: "Evening (6pm\u201312am)" },
+};
+
 export const DAYS_FROM_SUNDAY: Day[] = [
   "sunday",
   "monday",


### PR DESCRIPTION
## Summary
- Fixes #12 — users can select morning, afternoon, evening, or no preference on the availability page
- Scheduler prioritizes preferred-hour slots within each day, falls back to other available slots
- Preference stored in Firestore at `users/{uid}/preferences/studyTime`
- New `time.test.ts` with 6 tests for shared time utilities (partially addresses #6)
- 5 new scheduler tests for preference behavior
- Total: 28 tests across 2 files

## Test plan
- [x] All 28 tests pass
- [x] Build succeeds
- [x] Preference selector renders with 4 options
- [x] Scheduler correctly prioritizes preferred time range
- [x] Falls back to non-preferred slots when preferred hours are full
- [x] Day order preserved (preference doesn't pull later days forward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)