### PR TITLE
Add feedback loop: report actual time and improve future estimates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Session startup
+
+At the start of every session, before doing any work:
+1. Run `git fetch origin && git status` to check for remote changes
+2. Run `git pull origin main` to pull the latest main
+3. Review recent commits with `git log --oneline -10` to understand what changed
+
+This keeps the working context in sync and avoids building on stale code.
+
 ## Project
 
 Study Scheduler — a Next.js app that helps college students estimate assignment time using AI and auto-schedule study blocks into their week.
@@ -17,33 +26,29 @@ Test watch: `npm run test:watch`
 
 ## Architecture
 
-- **Next.js 16 App Router** with TypeScript and Tailwind CSS
+- **Next.js App Router** with TypeScript and Tailwind CSS
 - **4 pages:** `/` (dashboard), `/add` (assignment form), `/availability` (weekly grid), `/schedule` (calendar view)
-- **AI estimation:** `/api/estimate` route uses Vercel AI SDK (`generateText` + `Output.object()`) with `@ai-sdk/anthropic` (claude-sonnet-4-6) to estimate assignment duration from pasted text
-- **Scheduling:** `src/lib/scheduler.ts` — greedy algorithm sorts assignments by due date and fills earliest available 30-minute slots. Skips slots that have already passed. Flags assignments as "at risk" when not enough time before due date
 - **Auth:** Firebase Auth with Google Sign-in (`src/lib/auth.tsx`). `AuthGate` component blocks unauthenticated access
-- **Storage:** Firestore with user-scoped subcollections (`users/{uid}/assignments`, `users/{uid}/availability`) via `src/lib/storage.ts`
-- **Calendar import:** `/api/parse-schedule` route uses AI to extract free study windows from a calendar screenshot (uploaded on `/availability` page)
-- **Calendar:** `react-big-calendar` with `dayjs` localizer on the `/schedule` page. Study blocks are blue, busy blocks are gray
+- **Storage:** Firestore with user-scoped subcollections (`users/{uid}/assignments`, `users/{uid}/availability`) via `src/lib/storage.ts`. All functions are async and take `uid` as first argument
+- **Data fetching:** SWR hooks in `src/lib/hooks.ts` (`useAssignments`, `useAvailability`, `useStudyTimePreference`). Mutations go through `mutateXxx` functions in the same file
+- **AI estimation:** `/api/estimate` route uses Vercel AI SDK (`generateText` + `Output.object()`) with `@ai-sdk/anthropic` (claude-sonnet-4-6)
+- **Scheduling:** `src/lib/scheduler.ts` — greedy algorithm fills 30-minute slots within availability blocks, sorted by due date. Flags assignments as "at risk" when not enough time remains
+- **Availability:** Stored as `AvailabilityBlock[]` — array of `{ id, day, start, end }` with 24h HH:MM strings
+- **Study time preference:** `StudyTimePreference` type (`"morning" | "afternoon" | "evening" | "none"`) stored per user in Firestore under `preferences/studyTime`
+- **Calendar:** `react-big-calendar` with `dayjs` localizer on `/schedule`. Study blocks are blue, busy blocks are gray
 
 ## Infrastructure as Code
 
-We manage infrastructure configuration (Firestore rules, etc.) as checked-in files rather than clicking through web consoles. This means settings live in the repo (e.g., `firestore.rules`, `firebase.json`), are reviewed in PRs like any other code change, and are deployed via CLI commands. If a new service needs configuration, define it in a file and deploy it from the terminal — don't configure it manually in a dashboard.
+We manage infrastructure configuration (Firestore rules, etc.) as checked-in files rather than clicking through web consoles. Settings live in the repo (`firestore.rules`, `firebase.json`), are reviewed in PRs, and deployed via CLI. Don't configure manually in dashboards.
 
 ## Key conventions
 
-- Client components use `"use client"` directive — all pages are client-rendered except the API route
-- The `Availability` type is `AvailabilityBlock[]` — each block has `day: Day`, `start` (24h HH:MM), and `end` (see `types.ts`)
+- Client components use `"use client"` directive — all pages are client-rendered except API routes
+- Always get the current user from `useAuth()` and pass `user.uid` to storage/hook functions
 - The `ANTHROPIC_API_KEY` env var must be set for the AI estimation route to work
 - Six `NEXT_PUBLIC_FIREBASE_*` env vars configure Firebase (set in Vercel, pulled locally with `vercel env pull`)
 
-## Next steps
+## Git workflow
 
-- Add assignment URL field and link from calendar blocks (#8, assigned to Max)
-- Add feedback loop: report actual time after completing an assignment (#5, assigned to Max)
-- Adopt shadcn/ui component library for accessible, composable UI
-- Add overlap detection for availability blocks on the same day
-
-## Out of scope (planned for later)
-
-Google Calendar sync (live API), sharing/groups, resource recommendations, preferences (strengths/weaknesses)
+- Never commit directly to `main` — always branch and open a PR
+- Branch naming: `feat/`, `fix/`, `chore/` prefixes

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
-import { mutateAddAssignment } from "@/lib/hooks";
+import { mutateAddAssignment, useAssignments } from "@/lib/hooks";
 import DatePicker from "@/components/DatePicker";
 
 const ALLOWED_TYPES = new Set([
@@ -20,6 +20,7 @@ const MAX_FILE_BYTES = 20 * 1024 * 1024; // 20MB
 export default function AddAssignment() {
   const router = useRouter();
   const { user } = useAuth();
+  const { assignments } = useAssignments(user?.uid);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [title, setTitle] = useState("");
@@ -101,7 +102,19 @@ export default function AddAssignment() {
       const res = await fetch("/api/estimate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ description, fileData, fileName, fileMimeType }),
+        body: JSON.stringify({
+          description,
+          fileData,
+          fileName,
+          fileMimeType,
+          history: assignments
+            .filter((a) => a.actualMinutes != null)
+            .map((a) => ({
+              title: a.title,
+              estimatedMinutes: a.estimatedMinutes,
+              actualMinutes: a.actualMinutes!,
+            })),
+        }),
       });
 
       if (!res.ok) throw new Error("Estimation failed");

--- a/src/app/api/estimate/route.ts
+++ b/src/app/api/estimate/route.ts
@@ -12,11 +12,18 @@ const schema = z.object({
     .describe("Brief explanation of the estimate"),
 });
 
+const historyEntrySchema = z.object({
+  title: z.string(),
+  estimatedMinutes: z.number(),
+  actualMinutes: z.number(),
+});
+
 const requestSchema = z.object({
   description: z.string().optional(),
   fileData: z.string().optional(),
   fileName: z.string().optional(),
   fileMimeType: z.string().optional(),
+  history: z.array(historyEntrySchema).optional(),
 });
 
 export async function POST(req: Request) {
@@ -24,7 +31,7 @@ export async function POST(req: Request) {
   if (!parsed.success) {
     return Response.json({ error: "Invalid request" }, { status: 400 });
   }
-  const { description, fileData, fileName, fileMimeType } = parsed.data;
+  const { description, fileData, fileName, fileMimeType, history = [] } = parsed.data;
 
   const content: Array<TextPart | ImagePart | FilePart> = [];
 
@@ -49,11 +56,20 @@ export async function POST(req: Request) {
     return Response.json({ error: "No content provided" }, { status: 400 });
   }
 
+  const historyContext =
+    history.length > 0
+      ? "\n\nThis student's past assignment history (use to calibrate your estimate for this specific student):\n" +
+        history
+          .map((h) => `- "${h.title}": estimated ${h.estimatedMinutes}min, actually took ${h.actualMinutes}min`)
+          .join("\n")
+      : "";
+
   const { output } = await generateText({
     model: anthropic("claude-sonnet-4-6"),
     output: Output.object({ schema }),
     system:
-      "You are a study time estimator for college students. Given an assignment description, estimate how many minutes it will take an average college student to complete. Be realistic — students tend to underestimate. Return your estimate and a brief reasoning.",
+      "You are a study time estimator for college students. Given an assignment description, estimate how many minutes it will take an average college student to complete. Be realistic — students tend to underestimate. Return your estimate and a brief reasoning." +
+      historyContext,
     messages: [{ role: "user", content }],
     providerOptions: {
       anthropic: fileMimeType === "application/pdf"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,12 +4,14 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import dayjs from "dayjs";
 import { useAuth } from "@/lib/auth";
-import { useAssignments, mutateDeleteAssignment } from "@/lib/hooks";
+import { useAssignments, mutateDeleteAssignment, mutateUpdateAssignment } from "@/lib/hooks";
 
 export default function Dashboard() {
   const { user } = useAuth();
   const { assignments: raw, error: loadError } = useAssignments(user?.uid);
   const [error, setError] = useState("");
+  const [completingId, setCompletingId] = useState<string | null>(null);
+  const [actualHours, setActualHours] = useState("");
 
   const assignments = useMemo(
     () =>
@@ -20,6 +22,9 @@ export default function Dashboard() {
     [raw]
   );
 
+  const pending = assignments.filter((a) => !a.completedAt);
+  const completed = assignments.filter((a) => a.completedAt);
+
   async function handleDelete(id: string) {
     if (!user) return;
     if (!window.confirm("Delete this assignment? This cannot be undone.")) return;
@@ -29,6 +34,29 @@ export default function Dashboard() {
       setError("Could not delete assignment. Please try again.");
     }
   }
+
+  function handleStartComplete(id: string) {
+    setCompletingId(id);
+    setActualHours("");
+  }
+
+  async function handleSubmitActual(id: string) {
+    if (!user) return;
+    const minutes = Math.round(parseFloat(actualHours) * 60);
+    if (isNaN(minutes) || minutes <= 0) return;
+    try {
+      await mutateUpdateAssignment(user.uid, id, {
+        actualMinutes: minutes,
+        completedAt: new Date().toISOString(),
+      });
+    } catch {
+      setError("Could not save. Please try again.");
+    }
+    setCompletingId(null);
+  }
+
+  const fmtMinutes = (mins: number) =>
+    mins < 60 ? `${Math.round(mins)}m` : `${Math.round((mins / 60) * 10) / 10}h`;
 
   return (
     <div>
@@ -69,29 +97,126 @@ export default function Dashboard() {
           to get started.
         </p>
       ) : (
-        <div className="space-y-3">
-          {assignments.map((a) => (
-            <div
-              key={a.id}
-              className="flex items-start justify-between rounded-lg border border-zinc-200 p-4 dark:border-zinc-800"
-            >
-              <div>
-                <h2 className="font-semibold">{a.title}</h2>
-                <p className="mt-1 text-sm text-zinc-500">
-                  Due {dayjs(a.dueDate).format("ddd, MMM D")} &middot;{" "}
-                  {Math.round(a.estimatedMinutes / 60 * 10) / 10}h estimated
-                </p>
-                <p className="mt-1 text-sm text-zinc-400">{a.reasoning}</p>
-              </div>
-              <button
-                onClick={() => handleDelete(a.id)}
-                className="ml-4 text-sm text-red-500 hover:text-red-700"
-              >
-                Delete
-              </button>
+        <>
+          {pending.length > 0 && (
+            <div className="space-y-3">
+              {pending.map((a) => (
+                <div
+                  key={a.id}
+                  className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-800"
+                >
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <h2 className="font-semibold">{a.title}</h2>
+                      <p className="mt-1 text-sm text-zinc-500">
+                        Due {dayjs(a.dueDate).format("ddd, MMM D")} &middot;{" "}
+                        {fmtMinutes(a.estimatedMinutes)} estimated
+                      </p>
+                      <p className="mt-1 text-sm text-zinc-400">{a.reasoning}</p>
+                    </div>
+                    <div className="ml-4 flex gap-3">
+                      {completingId !== a.id && (
+                        <button
+                          onClick={() => handleStartComplete(a.id)}
+                          className="text-sm text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
+                        >
+                          Done
+                        </button>
+                      )}
+                      <button
+                        onClick={() => handleDelete(a.id)}
+                        className="text-sm text-red-500 hover:text-red-700"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+
+                  {completingId === a.id && (
+                    <div className="mt-3 flex items-center gap-2 border-t border-zinc-100 pt-3 dark:border-zinc-800">
+                      <label className="text-sm text-zinc-600 dark:text-zinc-400">
+                        How long did it actually take?
+                      </label>
+                      <input
+                        type="number"
+                        min="0.1"
+                        step="0.25"
+                        placeholder="hours"
+                        value={actualHours}
+                        onChange={(e) => setActualHours(e.target.value)}
+                        className="w-20 rounded border border-zinc-300 px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+                      />
+                      <span className="text-sm text-zinc-500">hrs</span>
+                      <button
+                        onClick={() => handleSubmitActual(a.id)}
+                        disabled={!actualHours || parseFloat(actualHours) <= 0}
+                        className="rounded bg-zinc-900 px-3 py-1 text-sm text-white hover:bg-zinc-700 disabled:opacity-40 dark:bg-zinc-100 dark:text-zinc-900"
+                      >
+                        Save
+                      </button>
+                      <button
+                        onClick={() => setCompletingId(null)}
+                        className="text-sm text-zinc-400 hover:text-zinc-600"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  )}
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+          )}
+
+          {completed.length > 0 && (
+            <div className="mt-8">
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-zinc-400">
+                Completed
+              </h2>
+              <div className="space-y-3">
+                {completed.map((a) => {
+                  const diffMins = Math.round((a.actualMinutes ?? 0) - a.estimatedMinutes);
+                  const diffLabel =
+                    diffMins === 0
+                      ? "exactly as estimated"
+                      : diffMins > 0
+                      ? `${fmtMinutes(diffMins)} over estimate`
+                      : `${fmtMinutes(Math.abs(diffMins))} under estimate`;
+                  return (
+                    <div
+                      key={a.id}
+                      className="flex items-start justify-between rounded-lg border border-zinc-100 p-4 opacity-60 dark:border-zinc-800"
+                    >
+                      <div>
+                        <h2 className="font-semibold line-through">{a.title}</h2>
+                        <p className="mt-1 text-sm text-zinc-500">
+                          {fmtMinutes(a.estimatedMinutes)} estimated &middot;{" "}
+                          {fmtMinutes(a.actualMinutes ?? 0)} actual &middot;{" "}
+                          <span
+                            className={
+                              diffMins > 0
+                                ? "text-red-500"
+                                : diffMins < 0
+                                ? "text-green-600"
+                                : "text-zinc-500"
+                            }
+                          >
+                            {diffLabel}
+                          </span>
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => handleDelete(a.id)}
+                        className="ml-4 text-sm text-red-400 hover:text-red-600"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -7,6 +7,7 @@ import {
   getStudyTimePreference,
   addAssignment,
   deleteAssignment,
+  updateAssignment,
   saveAvailability,
   saveStudyTimePreference,
 } from "./storage";
@@ -40,6 +41,16 @@ export async function mutateDeleteAssignment(uid: string, id: string) {
     { revalidate: false }
   );
   await deleteAssignment(uid, id);
+}
+
+export async function mutateUpdateAssignment(uid: string, id: string, patch: Partial<Assignment>) {
+  await mutate(
+    `assignments/${uid}`,
+    (current: Assignment[] | undefined) =>
+      current?.map((a) => (a.id === id ? { ...a, ...patch } : a)) ?? [],
+    { revalidate: false }
+  );
+  await updateAssignment(uid, id, patch);
 }
 
 // --- Availability ---

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -36,6 +36,10 @@ export async function deleteAssignment(uid: string, id: string) {
   await deleteDoc(doc(getDb(), "users", uid, "assignments", id));
 }
 
+export async function updateAssignment(uid: string, id: string, patch: Partial<Assignment>) {
+  await setDoc(doc(getDb(), "users", uid, "assignments", id), patch, { merge: true });
+}
+
 // --- Preferences ---
 
 export async function getStudyTimePreference(uid: string): Promise<StudyTimePreference> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,8 @@ export interface Assignment {
   estimatedMinutes: number;
   reasoning: string;
   createdAt: string;
+  actualMinutes?: number;
+  completedAt?: string; // ISO date string
 }
 
 export interface ScheduleBlock {


### PR DESCRIPTION
Closes #5

## Summary
- Adds a **Done** button on each pending assignment that records how long it actually took (in hours)
- Completed assignments move to a **Completed** section showing estimated vs actual time (e.g. "18m under estimate")
- Completed history is sent to `/api/estimate` on the next request so Claude can calibrate estimates to this student's specific pace

## Changes
- `types.ts` — adds `actualMinutes?` and `completedAt?` to `Assignment`
- `storage.ts` — adds `updateAssignment(uid, id, patch)` using Firestore merge
- `hooks.ts` — adds `mutateUpdateAssignment` with optimistic cache update
- `page.tsx` — feedback UI on dashboard (Done button, inline form, completed section)
- `add/page.tsx` — passes completed history to estimate API
- `api/estimate/route.ts` — includes history in system prompt when present
- `CLAUDE.md` — updated to reflect current Firebase/SWR architecture + session startup checklist

## Test plan
- [ ] Mark an assignment as done, enter actual hours, verify it moves to Completed with correct diff label
- [ ] Add a new assignment and confirm the estimate API call includes the history payload
- [ ] Verify completed assignments persist across page reloads (Firestore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)