### PR TITLE
Add assignment URL field and link from calendar blocks

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -24,6 +24,7 @@ export default function AddAssignment() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [title, setTitle] = useState("");
+  const [url, setUrl] = useState("");
   const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [loading, setLoading] = useState(false);
@@ -124,6 +125,7 @@ export default function AddAssignment() {
       await mutateAddAssignment(user.uid, {
         id: crypto.randomUUID(),
         title,
+        url: url.trim() || undefined,
         description: description.trim() || fileName || "Uploaded file",
         dueDate,
         estimatedMinutes,
@@ -151,6 +153,19 @@ export default function AddAssignment() {
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="e.g. Ochem Problem Set 5"
+            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">
+            Assignment URL{" "}
+            <span className="font-normal text-zinc-500">(optional)</span>
+          </label>
+          <input
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://canvas.instructure.com/..."
             className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
           />
         </div>

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -23,16 +23,27 @@ export default function SchedulePage() {
     return generateSchedule(assignments, availability, weekStart.toDate(), new Date(), preference);
   }, [assignments, availability, preference]);
 
+  const assignmentMap = useMemo(
+    () => Object.fromEntries(assignments.map((a) => [a.id, a])),
+    [assignments]
+  );
+
   const events = useMemo(
     () =>
       blocks.map((b) => ({
         title: b.title,
         start: new Date(b.start),
         end: new Date(b.end),
-        resource: b,
+        resource: { ...b, url: assignmentMap[b.assignmentId]?.url },
       })),
-    [blocks]
+    [blocks, assignmentMap]
   );
+
+  function handleSelectEvent(event: { resource: { url?: string } }) {
+    if (event.resource.url) {
+      window.open(event.resource.url, "_blank", "noopener,noreferrer");
+    }
+  }
 
   const error = assignErr || availErr;
   const atRiskAssignments = assignments.filter((a) => atRisk.includes(a.id));
@@ -69,9 +80,11 @@ export default function SchedulePage() {
           min={new Date(2024, 0, 1, 7, 0)}
           max={new Date(2024, 0, 1, 23, 0)}
           style={{ height: 700 }}
+          onSelectEvent={handleSelectEvent}
           eventPropGetter={(event) => ({
             className:
               event.resource.type === "study" ? "study-block" : "busy-block",
+            style: event.resource.url ? { cursor: "pointer" } : undefined,
           })}
         />
       )}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,7 @@ export interface Assignment {
   estimatedMinutes: number;
   reasoning: string;
   createdAt: string;
+  url?: string;
   actualMinutes?: number;
   completedAt?: string; // ISO date string
 }


### PR DESCRIPTION
Closes #8

## Summary
- Adds an optional **Assignment URL** field on the add-assignment form (e.g. Canvas, Google Doc, course page)
- Clicking a study block on the calendar opens the URL in a new tab
- Blocks with a URL show a pointer cursor as a visual hint

## Test plan
- [ ] Add an assignment with a URL — confirm it saves correctly
- [ ] Add an assignment without a URL — confirm nothing breaks
- [ ] Click a block with a URL on the schedule page — confirm it opens in a new tab
- [ ] Click a block without a URL — confirm nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)